### PR TITLE
Date tests: don't care about time zone offset

### DIFF
--- a/spec/collectionspace/mapper/tools/dates_spec.rb
+++ b/spec/collectionspace/mapper/tools/dates_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CollectionSpace::Mapper::Tools::Dates do
       
       it 'populates .timestamp' do
         res = @res.timestamp.to_s
-        expect(res).to eq('2020-09-30 12:00:00 -0400')
+        expect(res).to start_with('2020-09-30 12:00:00')
       end
 
       it '.mappable dateDisplayDate = 2020-09-30' do


### PR DESCRIPTION
CollectionSpace-generated structured date scalar values are created by appending constant value 'T00:00:00.000Z' to the date from the timestamp tested by the changed code. The timezone offset is irrelevant here and was causing tests run by folks in other time zones to fail. 