### PR TITLE
Drop blank fields after transform/combine

### DIFF
--- a/lib/collectionspace/mapper/data_prepper.rb
+++ b/lib/collectionspace/mapper/data_prepper.rb
@@ -210,6 +210,11 @@ module CollectionSpace
             end
           end
         end
+
+        @response.combined_data[xpath].select{ |fieldname, val| val.blank? }.keys.each do |fieldname|
+          @response.combined_data[xpath].delete(fieldname)
+          @xphash[xpath][:mappings].delete_if{ |mapping| mapping[:fieldname] == fieldname }
+        end
       end
 
       def combine_subgroup_values(data)

--- a/spec/fixtures/files/datahashes/core/conservation0_1.json
+++ b/spec/fixtures/files/datahashes/core/conservation0_1.json
@@ -1,0 +1,5 @@
+{
+    "conservationNumber": "CT2020.7",
+    "status": "Analysis complete;Treatment approved;;Treatment in progress",
+    "statusDate": ""
+}


### PR DESCRIPTION
There are potential reasons to maintain blank fields for the transformation stage (booleans) or combination stage (position offsets in multi-authority, multi-value groups). But when we get done combining fields into the final CollectionSpace XML fields, we should not keep and attempt to map completely blank fields. 