### PR TITLE
merge any default data into datahash pre-validation or prep

### DIFF
--- a/lib/collectionspace/mapper/authority_hierarchy_prepper.rb
+++ b/lib/collectionspace/mapper/authority_hierarchy_prepper.rb
@@ -9,14 +9,14 @@ module CollectionSpace
       def initialize(data, handler)
         super
         @cache = @handler.csidcache
-        @type = @data['term_type']
-        @subtype = @data['term_subtype']
+        @type = @response.merged_data['term_type']
+        @subtype = @response.merged_data['term_subtype']
         @errors = []
         @warnings = []
       end
       
       def prep
-        @response.identifier = "#{@data['broader_term']} > #{@data['narrower_term']}"
+        @response.identifier = "#{@response.merged_data['broader_term']} > #{@response.merged_data['narrower_term']}"
         split_data
         transform_terms
         combine_data_fields

--- a/lib/collectionspace/mapper/data_handler.rb
+++ b/lib/collectionspace/mapper/data_handler.rb
@@ -34,7 +34,7 @@ module CollectionSpace
       end
 
       def process(data)
-        response = CollectionSpace::Mapper::setup_data(data)
+        response = CollectionSpace::Mapper::setup_data(data, @defaults, @config)
           if response.valid?
             case record_type
             when 'authorityhierarchy'
@@ -87,7 +87,8 @@ module CollectionSpace
       end
       
       def validate(data)
-        @validator.validate(data)
+        response = CollectionSpace::Mapper::setup_data(data, @defaults, @config)
+        @validator.validate(response)
       end
 
       def prep(data)

--- a/lib/collectionspace/mapper/data_prepper.rb
+++ b/lib/collectionspace/mapper/data_prepper.rb
@@ -10,10 +10,8 @@ module CollectionSpace
         @config = @handler.config
         @cache = @handler.cache
         @client = @handler.client
-        @response = CollectionSpace::Mapper::setup_data(data)
+        @response = CollectionSpace::Mapper::setup_data(data, @handler.defaults, @config)
         if @response.valid?
-          @data = @response.orig_data.transform_keys(&:downcase)
-          @response.merged_data = merge_default_values
           process_xpaths
         end
       end
@@ -63,19 +61,6 @@ module CollectionSpace
       end
 
       private
-
-      def merge_default_values
-        mdata = @data.clone
-        @handler.defaults.each do |f, val|
-          if @config[:force_defaults]
-            mdata[f] = val
-          else
-            dataval = @data.fetch(f, nil)
-            mdata[f] = val if dataval.nil? || dataval.empty?
-          end
-        end
-        mdata.compact
-      end
 
       def process_xpaths
         # keep only mappings for datacolumns present in data hash

--- a/lib/collectionspace/mapper/data_validator.rb
+++ b/lib/collectionspace/mapper/data_validator.rb
@@ -83,7 +83,7 @@ module CollectionSpace
       def validate(data)
         response = CollectionSpace::Mapper::setup_data(data)
         if response.valid?
-          data = data.transform_keys!(&:downcase)
+          data = response.merged_data.transform_keys!(&:downcase)
           res = check_required_fields(data) unless @required_fields.empty?
           response.errors << res
           response.errors = response.errors.flatten.compact

--- a/lib/collectionspace/mapper/non_hierarchical_relationship_prepper.rb
+++ b/lib/collectionspace/mapper/non_hierarchical_relationship_prepper.rb
@@ -9,7 +9,7 @@ module CollectionSpace
       def initialize(data, handler)
         super
         @cache = @handler.csidcache
-        @types = [@data['item1_type'], @data['item2_type']]
+        @types = [@response.merged_data['item1_type'], @response.merged_data['item2_type']]
         @errors = []
         @warnings = []
         @responses = []
@@ -30,11 +30,10 @@ module CollectionSpace
       def stringify_item(i)
         id = "item#{i}_id"
         type = "item#{i}_type"
-        thisid = @data[id]
-        thistype = @data[type]
+        thisid = @response.merged_data[id]
+        thistype = @response.merged_data[type]
         "#{thisid} (#{thistype})"
       end
-
 
       def flip_response
         resp2 = @response.dup

--- a/lib/collectionspace/mapper/version.rb
+++ b/lib/collectionspace/mapper/version.rb
@@ -1,5 +1,5 @@
 module CollectionSpace
   module Mapper
-    VERSION = "2.2.0"
+    VERSION = "2.2.1"
   end
 end

--- a/spec/collectionspace/mapper/data_validator_spec.rb
+++ b/spec/collectionspace/mapper/data_validator_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe CollectionSpace::Mapper::DataValidator do
     @anthro_dv = CollectionSpace::Mapper::DataValidator.new(CollectionSpace::Mapper::Tools::RecordMapper.convert(@anthro_object_mapper), anthro_cache)
     @botgarden_loanout_mapper = get_json_record_mapper(path: 'spec/fixtures/files/mappers/release_6_1/botgarden/botgarden_2_0_1-loanout.json')
     @botgarden_dv = CollectionSpace::Mapper::DataValidator.new(CollectionSpace::Mapper::Tools::RecordMapper.convert(@botgarden_loanout_mapper), botgarden_cache)
+    @core_authhier_mapper = get_json_record_mapper(path: 'spec/fixtures/files/mappers/release_6_1/core/core_6-1-0_authorityhierarchy.json')
+    @core_authhier_dv = CollectionSpace::Mapper::DataValidator.new(CollectionSpace::Mapper::Tools::RecordMapper.convert(@core_authhier_mapper), core_cache)
   end
 
   describe '#validate' do
@@ -143,6 +145,19 @@ RSpec.describe CollectionSpace::Mapper::DataValidator do
           v = @anthro_dv.validate(data)
           err = v.errors.select{ |err| err.start_with?('required field missing') }
           expect(err.size).to eq(1)
+        end
+      end
+
+      context 'when required field not present in data but provided by defaults' do
+        it 'no required field error returned' do
+          handler = CollectionSpace::Mapper::DataHandler.new(record_mapper: @core_authhier_mapper,
+                                                                      client: core_client,
+                                                                      cache: core_cache)
+          data = get_datahash(path: 'spec/fixtures/files/datahashes/core/authorityHierarchy1.json')
+          v = handler.validate(data)
+          err = v.errors.select{ |err| err.start_with?('required field') }
+          puts err
+          expect(err.size).to eq(0)
         end
       end
     end

--- a/spec/fixtures/files/mappers/release_6_1/core/core_6-1-0_authorityhierarchy.json
+++ b/spec/fixtures/files/mappers/release_6_1/core/core_6-1-0_authorityhierarchy.json
@@ -11,7 +11,7 @@
     "ns_uri": {
       "relations_common": "http://collectionspace.org/services/relation"
     },
-    "identifier_field": "csid",
+    "identifier_field": "subjectCsid",
     "search_field": "term"
   },
   "docstructure": {
@@ -48,7 +48,7 @@
         "workauthorities"
       ],
       "datacolumn": "term_type",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "termSubType",
@@ -83,7 +83,7 @@
         "worldcat"
       ],
       "datacolumn": "term_subtype",
-      "required": "y"
+      "required": "y in template"
     },
     {
       "fieldname": "subjectCsid",


### PR DESCRIPTION
For special recordtypes, required fields are provided in defaults
hardcoded in the DataHandler. Calling `handler.validate` on the raw
data resulted in errors about missing required fields. Merging any
default data in as soon as the data is first prepped into a Response
ensures this doesn't happen any more.