### PR TITLE
add `DataHandler.service_type` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project bumps the version number for any changes (including documentation u
 
 ## [Unreleased]
 
+## [2.4.0] - 2021-05-17
+### Added
+- Public `DataHandler.service_type` method so that `cspace-batch-import` does not reach into the guts of the class for that info
+
+Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.3.2...v2.3.3
+
 ## [2.3.1], [2.3.2] - 2021-05-17
 ### Deleted 
 - Development dependency on ruby-prof that should not have been committed

--- a/lib/collectionspace/mapper/data_handler.rb
+++ b/lib/collectionspace/mapper/data_handler.rb
@@ -64,6 +64,11 @@ module CollectionSpace
         known = data_fields - unknown
         { known_fields: known, unknown_fields: unknown }
       end
+
+      # this is surfaced in public interface because it is used by cspace-batch-import
+      def service_type
+        @mapper.config.service_type
+      end
       
       def validate(data)
         response = CollectionSpace::Mapper::setup_data(data, @mapper.batchconfig)

--- a/lib/collectionspace/mapper/version.rb
+++ b/lib/collectionspace/mapper/version.rb
@@ -1,5 +1,5 @@
 module CollectionSpace
   module Mapper
-    VERSION = "2.3.2"
+    VERSION = "2.4.0"
   end
 end

--- a/spec/collectionspace/mapper/data_handler_spec.rb
+++ b/spec/collectionspace/mapper/data_handler_spec.rb
@@ -92,6 +92,37 @@ end
     end
   end
 
+  describe '#service_type' do
+    let(:servicetype) { handler.service_type }
+    context 'anthro profile' do
+      context 'collectionobject record' do
+        let(:handler) { @anthro_object_handler }
+
+        it 'returns object' do
+          expect(servicetype).to eq('object')
+        end
+      end
+
+      context 'place record' do
+        let(:handler) { @anthro_place_handler }
+
+        it 'returns authority' do
+          expect(servicetype).to eq('authority')
+        end
+      end
+    end
+
+    context 'bonsai profile' do
+      context 'conservation record' do
+        let(:handler) { @bonsai_conservation_handler }
+
+        it 'returns procedure' do
+          expect(servicetype).to eq('procedure')
+        end
+      end
+    end
+  end
+  
   describe '#xpath_hash' do
     context 'anthro profile' do
       context 'collectionobject record' do


### PR DESCRIPTION
`cspace-batch-import` was previously chaining into the guts of read
attributes of this class, which is baaaad, so I am putting this in the
public interface of DataHandler.