### PR TITLE
Bump client and refcache versions; require dependencies explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,20 @@ This project bumps the version number for any changes (including documentation u
 
 ## [Unreleased]
 
+## [2.4.4] - 2021-06-29
+### Changed
+- Bumps version of `collectionspace-client` to 0.8.0, to add support for all 6.1 record types and new 7.0 record types
+- Bumps version of `collectionspace-refcache` to 0.7.4, which now also depends on `collectionspace-client` 0.8.0
+- Sorts Dir files before requiring them to avoid load-order problems that are tricky to reproduce
+- Explicitly requires dependent files to fix failures highlighted by introducing sort before requiring
+
+Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.4.3...v2.4.4
+
 ## [2.4.3] - 2021-06-21
 ### Changed
 - Bumps version of `collectionspace-refcache` to 0.7.3, as this is the version now required by `collectionspace-csv-importer` for playing nice with Heroku
+
+Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.4.2...v2.4.3
 
 ## [2.4.2] - 2021-06-07
 ### Added
@@ -21,6 +32,8 @@ This project bumps the version number for any changes (including documentation u
 ### Changed
 - Refactored core mapper tests
 
+Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.4.1...v2.4.2
+
 ## [2.4.1] - 2021-06-02
 ### Added
 - Tests for vocabulary/authority-controlled fields containing %NULLVALUE% and THE BOMB
@@ -28,11 +41,13 @@ This project bumps the version number for any changes (including documentation u
 ### Changed
 - Term handler now passes through %NULLVALUE% as an empty string, and passes 💣 through as 💣. This means you no longer get spurious "not found" term warnings about these values, and they have the expected result when imported.
 
+Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.4.0...v2.4.1
+
 ## [2.4.0] - 2021-05-17
 ### Added
 - Public `DataHandler.service_type` method so that `cspace-batch-import` does not reach into the guts of the class for that info
 
-Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.3.2...v2.3.3
+Details: https://github.com/collectionspace/collectionspace-mapper/compare/v2.3.2...v2.4.0
 
 ## [2.3.1], [2.3.2] - 2021-05-17
 ### Deleted 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem 'facets', require: false
 
 # Specify your gem's dependencies in collectionspace-mapper.gemspec
-gem 'collectionspace-client', tag: 'v0.7.0', git: 'https://github.com/collectionspace/collectionspace-client.git'
-gem 'collectionspace-refcache', tag: 'v0.7.3', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
+gem 'collectionspace-client', tag: 'v0.8.0', git: 'https://github.com/collectionspace/collectionspace-client.git'
+gem 'collectionspace-refcache', tag: 'v0.7.4', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
 gemspec

--- a/lib/collectionspace/mapper.rb
+++ b/lib/collectionspace/mapper.rb
@@ -20,13 +20,13 @@ module CollectionSpace
 
     THE_BOMB = "\u{1F4A3}"
     
-    Dir[File.dirname(__FILE__) + 'mapper/tools/*.rb'].each do |file|
+    Dir[File.dirname(__FILE__) + 'mapper/tools/*.rb'].sort.each do |file|
       require "collectionspace/mapper/tools/#{File.basename(file, File.extname(file))}"
     end
-    Dir[File.dirname(__FILE__) + '/mapper/identifiers/*.rb'].each do |file|
+    Dir[File.dirname(__FILE__) + '/mapper/identifiers/*.rb'].sort.each do |file|
       require "collectionspace/mapper/identifiers/#{File.basename(file, File.extname(file))}"
     end
-    Dir[File.dirname(__FILE__) + '/mapper/*.rb'].each do |file|
+    Dir[File.dirname(__FILE__) + '/mapper/*.rb'].sort.each do |file|
       require "collectionspace/mapper/#{File.basename(file, File.extname(file))}"
     end
 

--- a/lib/collectionspace/mapper/authority_hierarchy_prepper.rb
+++ b/lib/collectionspace/mapper/authority_hierarchy_prepper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'data_prepper'
+require_relative 'term_searchable'
+
 module CollectionSpace
   module Mapper
     class AuthorityHierarchyPrepper < CollectionSpace::Mapper::DataPrepper

--- a/lib/collectionspace/mapper/config.rb
+++ b/lib/collectionspace/mapper/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'tools/symbolizable'
+
 module CollectionSpace
   module Mapper
 

--- a/lib/collectionspace/mapper/version.rb
+++ b/lib/collectionspace/mapper/version.rb
@@ -1,5 +1,5 @@
 module CollectionSpace
   module Mapper
-    VERSION = "2.4.3"
+    VERSION = "2.4.4"
   end
 end

--- a/lib/collectionspace/mapper/version.rb
+++ b/lib/collectionspace/mapper/version.rb
@@ -1,5 +1,5 @@
 module CollectionSpace
   module Mapper
-    VERSION = "2.4.4"
+    VERSION = "2.4.5"
   end
 end


### PR DESCRIPTION
- Bumps version of `collectionspace-client` to 0.8.0, to add support for all 6.1 record types and new 7.0 record types
- Bumps version of `collectionspace-refcache` to 0.7.4, which now also depends on `collectionspace-client` 0.8.0
- Sorts Dir files before requiring them to avoid load-order problems that are tricky to reproduce
- Explicitly requires dependent files to fix failures highlighted by introducing sort before requiring