### PR TITLE
Fix mapper error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project bumps the version number for any changes (including documentation u
 
 ## [Unreleased] - i.e. pushed to main branch but not yet tagged as a release
 
+## [4.0.4] - 2022-07-12
+- Stop adding duplicate "missing term" errors at point of retrieving client search results and later processing those results
+- Ensure equivalence of interface (duck typing) for RefName and UnknownTerm classes
+- Dev: clean up old comments/commented out code; run tests in deterministic random order (i.e. with reported seed); aggregate failures in tests globally via config
+
 ## [4.0.3] - 2022-06-23
 - BUGFIX: Fixes error when calling `mappable` on a `ChronicParser` initialized with a date string Chronic cannot parse  - [PR 144](https://github.com/collectionspace/collectionspace-mapper/pull/144)
 - Replace `facets` gem with `activesupport` - [PR 141](https://github.com/collectionspace/collectionspace-mapper/pull/141)

--- a/lib/collectionspace/mapper/term_handler.rb
+++ b/lib/collectionspace/mapper/term_handler.rb
@@ -98,11 +98,6 @@ module CollectionSpace
         @terms << term_report.merge({found: found, refname: refname_obj})
       end
 
-      # the next two methods need to be updated when not-found terms become blocking errors instead
-      #  of warnings. At that point, we no longer want to generate and store a refname for the
-      #  term, since it will not be mapped.
-      # at the point of switching error, the termtype and termsubtype parameters can be removed from
-      #  cached_term
       def add_new_unknown_term(val, term_report)
         unknown_term = CollectionSpace::Mapper::UnknownTerm.new(
           type: type,
@@ -123,18 +118,6 @@ module CollectionSpace
         add_missing_record_error('term', val)
         unknown_term_str
       end
-
-      # def add_new_unknown_term(val, term_report)
-      #   @terms << term_report.merge({found: false, refname: 'null'})
-      #   @cache.put('unknownvalue', type_subtype, val, 'null')
-      #   'null'
-      # end
-
-      # def add_known_unknown_term(val, term_report)
-      #   @terms << term_report.merge({found: false, refname: 'null'})
-      #   add_missing_record_error('term', val)
-      #   'null'
-      # end
     end
   end
 end

--- a/lib/collectionspace/mapper/term_searchable.rb
+++ b/lib/collectionspace/mapper/term_searchable.rb
@@ -146,7 +146,6 @@ module CollectionSpace
 
         case term_ct
         when 0
-          add_missing_record_error(category, val)
           rec = nil
         when 1
           rec = response['list_item']

--- a/lib/collectionspace/mapper/unknown_term.rb
+++ b/lib/collectionspace/mapper/unknown_term.rb
@@ -20,7 +20,7 @@ module CollectionSpace
         self.new(type: parts[0], subtype: parts[1], term: parts[2])
       end
       
-      attr_reader :type, :subtype, :display_name, :urn
+      attr_reader :type, :subtype, :identifier, :display_name, :urn
       
       def initialize(type:, subtype:, term:)
         @type = type

--- a/lib/collectionspace/mapper/version.rb
+++ b/lib/collectionspace/mapper/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   module Mapper
-    VERSION = '4.0.3'
+    VERSION = '4.0.4'
   end
 end

--- a/spec/collectionspace/mapper/dates/chronic_parser_spec.rb
+++ b/spec/collectionspace/mapper/dates/chronic_parser_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CollectionSpace::Mapper::Dates::ChronicParser do
     context 'with 01-00-2000' do
       let(:str){ '01-00-2000' }
 
-      it 'returns expected', :aggregate_failures do
+      it 'returns expected' do
         expect(parser.mappable['dateDisplayDate']).to eq(str)
         expect(parser.mappable['scalarValuesComputed']).to eq('false')
       end

--- a/spec/collectionspace/mapper/dates/services_parser_spec.rb
+++ b/spec/collectionspace/mapper/dates/services_parser_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CollectionSpace::Mapper::Dates::ServicesParser do
     context 'with 01-00-2000' do
       let(:str){ '01-00-2000' }
 
-      it 'returns expected', :aggregate_failures do
+      it 'returns expected' do
         expect(parser.mappable['dateDisplayDate']).to eq(str)
         expect(parser.mappable['scalarValuesComputed']).to eq('false')
       end

--- a/spec/collectionspace/mapper/dates/structured_date_handler_spec.rb
+++ b/spec/collectionspace/mapper/dates/structured_date_handler_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CollectionSpace::Mapper::Dates::StructuredDateHandler do
     context 'when term is cached' do
       let(:domain){ 'c.anthro.collectionspace.org' }
       it 'returns expected refname' do
+        cache.put_vocab_term('dateera', 'CE', refname)
         expect(result).to eq(refname)
       end
     end

--- a/spec/collectionspace/mapper/term_handler_spec.rb
+++ b/spec/collectionspace/mapper/term_handler_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe CollectionSpace::Mapper::TermHandler do
                      "urn:cspace:c.core.collectionspace.org:vocabularies:name(languages):item:name(spa)'Spanish'"],
                     [CollectionSpace::Mapper::THE_BOMB]]
         expect(th.result).to eq(expected)
+        expect(th.errors.length).to eq(1)
       end
     end
 

--- a/spec/collectionspace/mapper/term_searchable_spec.rb
+++ b/spec/collectionspace/mapper/term_searchable_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe CollectionSpace::Mapper::TermSearchable do
 
     context 'when not cached as unknown value' do
       it 'returns false' do
+        cache.remove('unknownvalue', "#{termtype}/#{termsubtype}", val)
         expect(result).to be false
       end
     end

--- a/spec/collectionspace/mapper/tools/dates_spec.rb
+++ b/spec/collectionspace/mapper/tools/dates_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CollectionSpace::Mapper::Tools::Dates do
     context 'with one digit month' do
       let(:date_string){ '2019-5-20' }
 
-      it 'parses as expected', :aggregate_failures do
+      it 'parses as expected' do
         expect(csdate.mappable['dateEarliestScalarValue']).to start_with('2019-05-20')
         expect(csdate.mappable['dateDisplayDate']).to eq(date_string)
       end

--- a/spec/collectionspace/mapper/unknown_term_spec.rb
+++ b/spec/collectionspace/mapper/unknown_term_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CollectionSpace::Mapper::UnknownTerm do
     context 'with valid string (3 parts, separated by `|||`)' do
       let(:str){ 'a|||b|||c' }
 
-      it 'creates new as expected', :aggregate_failures do
+      it 'creates new as expected' do
         expect(result).to be_a(described_class)
         expect(result.type).to eq('a')
         expect(result.subtype).to eq('b')
@@ -21,7 +21,7 @@ RSpec.describe CollectionSpace::Mapper::UnknownTerm do
     context 'with nil' do
       let(:str){ nil }
 
-      it 'fails', :aggregate_failures do
+      it 'fails' do
         expect{ result }.to raise_error(CollectionSpace::Mapper::UnknownTerm::ReconstituteNilError)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ RSpec.configure do |config|
     c.max_formatted_output_length = nil
   end
 
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
+
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ require_relative './helpers'
 RSpec.configure do |config|
   config.include Helpers
 
+  # random but deterministic test order
+  config.order = :random
+  Kernel.srand config.seed
+  
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 


### PR DESCRIPTION
- Stop adding duplicate "missing term" errors at point of retrieving client search results (in `TermSearchable`) and later processing those results (in `TermHandler`)
- Ensure equivalence of interface (duck typing) for `RefName` and `UnknownTerm` classes
- Dev: clean up old comments/commented out code; run tests in deterministic random order (i.e. with reported seed); aggregate failures in tests globally via config