### PR TITLE
Add ability to create vocabulary terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project bumps the version number for any changes (including documentation u
 
 ## [Unreleased] - i.e. pushed to main branch but not yet tagged as a release
 
+## [4.1.0] - 2022-11-17
+- Adds ability to create new vocabulary terms. See [usage documentation](https://github.com/collectionspace/collectionspace-mapper/blob/main/doc/usage.adoc#add-vocabulary-terms).
+
 ## [4.0.7] - 2022-10-18
 - BUGFIX for #129 and #142
 

--- a/collectionspace-mapper.gemspec
+++ b/collectionspace-mapper.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '= 6.0.4.7' # version used by collectionspace-csv-importer
   spec.add_dependency 'chronic'
   spec.add_dependency 'dry-configurable', '~>0.14'
+  spec.add_dependency 'dry-monads', '~>1.4'
   spec.add_dependency 'memo_wise', '~> 1.1.0'
   spec.add_dependency 'nokogiri', '~> 1.13.3'
   spec.add_dependency 'xxhash', '>= 0.4.0'

--- a/doc/usage.adoc
+++ b/doc/usage.adoc
@@ -28,7 +28,7 @@ RecordMapper JSON files for all current profile/rectype combinations can be foun
 
 These JSON files should be parsed before passing to this application.
 
-Sample simple setup could look like: 
+Sample simple setup could look like:
 
 [source,ruby]
 ----
@@ -103,7 +103,7 @@ handler = DataHandler.new(
 
 Each row or record of data to be mapped should be passed in as a Hash.
 
-Hash keys are Strings and should match headers from the CSV templates output by `cspace-config-untangler`. Keys that do not match CSV headers will not be mapped. 
+Hash keys are Strings and should match headers from the CSV templates output by `cspace-config-untangler`. Keys that do not match CSV headers will not be mapped.
 
 Hash values are Strings. You can also pass through null Hash values.
 
@@ -122,7 +122,7 @@ handler.check_fields(data)
      }
 ----
 
-A warning about the unknown `conservator` field will be very valuable to a user who doesn't realize they must use `conservatorperson` or `conservatororganization` as their CSV headers. 
+A warning about the unknown `conservator` field will be very valuable to a user who doesn't realize they must use `conservatorperson` or `conservatororganization` as their CSV headers.
 
 === Validating a record
 
@@ -288,3 +288,23 @@ pp(processed)
         :value=>"test",
         :message=>"Unknown value in option list `recordstatus` column"}]>
 ----
+
+
+== Other features
+
+=== Add vocabulary terms
+
+This example assumes you have already defined a `client`.
+
+[source,ruby]
+----
+vh = CollectionSpace::Mapper::VocabularyTerms::Handler.new(client: client)
+vh.add_term(vocab: 'Annotation Type', term: 'Credit line')
+=> Success("/vocabularies/e1401111-05c2-4d6c-bdc5/items/ef050e28-ae81-46c0-8e8b") <1>
+vh.add_term(vocab: 'annotationType', term: 'Credit line')
+=> Failure("annotationtype/Credit Line already exists") <2>
+----
+<1> When response.status_code = 201
+<2> When response.status_code = 409. For other non-success responses, the response itself will be returned in the Failure.
+
+Calling `add_term` returns a https://dry-rb.org/gems/dry-monads/main/result/[dry-monads Result Success or Failure].

--- a/lib/collectionspace/mapper/version.rb
+++ b/lib/collectionspace/mapper/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   module Mapper
-    VERSION = '4.0.7'
+    VERSION = '4.1.0'
   end
 end

--- a/lib/collectionspace/mapper/vocabularies.rb
+++ b/lib/collectionspace/mapper/vocabularies.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+
+module CollectionSpace
+  module Mapper
+    # Various types of access to the vocabularies defined in a CS instance
+    class Vocabularies
+      include Dry::Monads[:result]
+
+      def initialize(client)
+        @vocabs = populate_vocabs(client)
+      end
+
+      # @param name [String] display or machine name of vocabulary
+      def by_name(name)
+        result = vocabs.select{ |vocab| vocab['displayName'] == name }
+
+        if result.empty?
+          result = vocabs.select do |vocab|
+            vocab['shortIdentifier'].downcase == name.downcase
+          end
+        end
+
+        if result.empty?
+          Failure("Vocabulary `#{name}` does not exist")
+        else
+          Success(result.first)
+        end
+      end
+
+      private
+
+      attr_reader :vocabs
+
+      def populate_vocabs(client)
+        all = []
+        client.all('vocabularies').each{ |v| all << v }
+        all
+      end
+    end
+  end
+end

--- a/lib/collectionspace/mapper/vocabulary_terms/handler.rb
+++ b/lib/collectionspace/mapper/vocabulary_terms/handler.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module CollectionSpace
+  module Mapper
+    module VocabularyTerms
+      # Sets up a class with client context, that can process terms from multiple
+      #   vocabularies
+      class Handler
+        include Dry::Monads[:result]
+        include Dry::Monads::Do.for(:add_term)
+
+        def initialize(client:,
+                       vocabs: CollectionSpace::Mapper::Vocabularies.new(client)
+                      )
+          @client = client
+          @domain = client.domain
+          @vocabs = vocabs
+        end
+
+        # @param vocab [String] the display name of the target Vocabulary
+        # @param term [String] the term to create in the Vocabulary
+        def add_term(vocab:, term:)
+          vocabulary = yield vocabs.by_name(vocab)
+          vname = vocabulary['shortIdentifier']
+          vcsid = vocabulary['csid']
+          tid = yield get_termid(term)
+          payload = yield PayloadBuilder.call(
+            domain: domain,
+            csid: vcsid,
+            name: vname,
+            term: term,
+            termid: tid
+          )
+          path = "#{vocabulary['uri']}/items"
+          posting = yield post_term(path, payload, vname, term)
+
+          Success(posting.sub(/^.*cspace-services/, ''))
+        end
+
+        private
+
+        attr_reader :client, :domain, :vocabs
+
+        def get_termid(term)
+          result = CollectionSpace::Mapper::Identifiers::ShortIdentifier.new(
+            term: term
+          ).value
+        rescue StandardError => err
+          Failure(err)
+        else
+          Success(result)
+        end
+
+        def post_term(path, payload, vname, term)
+          result = client.post(path, payload)
+        rescue StandardError => err
+          Failure(err)
+        else
+          case result.status_code
+          when 409
+            Failure("#{vname}/#{term} already exists")
+          when 201
+            Success(result.result.headers['location'])
+          else
+            Failure(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/collectionspace/mapper/vocabulary_terms/payload_builder.rb
+++ b/lib/collectionspace/mapper/vocabulary_terms/payload_builder.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+
+module CollectionSpace
+  module Mapper
+    module VocabularyTerms
+      # Sets up a class with client context, that can process terms from multiple
+      #   vocabularies
+      class PayloadBuilder
+        extend Dry::Monads[:result]
+
+        # @param domain [String] CS client domain
+        # @param csid [String] CSID of vocabulary
+        # @param name [String] machine name of vocabulary
+        # @param term [String] to be created
+        # @param termid [String] shortidentifier value of term
+        def self.call(domain:, csid:, name:, term:, termid:)
+          payload = <<~XML
+            <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+            <document name="vocabularyitems">
+                <ns2:vocabularyitems_common
+                   xmlns:ns2="http://collectionspace.org/services/vocabulary"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                   <inAuthority>#{csid}</inAuthority>
+                   <displayName>#{term}</displayName>
+                   <shortIdentifier>#{termid}</shortIdentifier>
+                   <refName>
+                     urn:cspace:#{domain}:vocabularies:name(#{name}):item:name(#{termid})'#{term}'
+                   </refName>
+                </ns2:vocabularyitems_common>
+            </document>
+            XML
+          Success(payload)
+        end
+      end
+    end
+  end
+end

--- a/spec/collectionspace/mapper/vocabularies_spec.rb
+++ b/spec/collectionspace/mapper/vocabularies_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CollectionSpace::Mapper::Vocabularies do
+  let(:client){ core_client }
+  subject(:vocabs){ described_class.new(client) }
+
+  describe '#by_name' do
+    it 'returns as expected' do
+      expect(vocabs.by_name('Annotation Type')).to be_a(Dry::Monads::Success)
+      expect(vocabs.by_name('foo')).to be_a(Dry::Monads::Failure)
+      expect(vocabs.by_name('acousticalproperties')).to be_a(
+        Dry::Monads::Success
+      )
+      expect(vocabs.by_name('acousticalProperties')).to be_a(
+        Dry::Monads::Success
+      )
+    end
+  end
+end

--- a/spec/collectionspace/mapper/vocabulary_terms/handler_spec.rb
+++ b/spec/collectionspace/mapper/vocabulary_terms/handler_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CollectionSpace::Mapper::VocabularyTerms::Handler do
+  subject(:handler){ described_class.new(client: client) }
+  let(:client){ core_client }
+
+  describe '#add_term' do
+    let(:result){ handler.add_term(vocab: vocab, term: term) }
+
+    context 'with existing term' do
+      let(:vocab){ 'Annotation Type' }
+      let(:term){ 'nomenclature' }
+      it 'returns Failure' do
+        expect(result).to be_a(Dry::Monads::Failure)
+        failmsg = 'annotationtype/nomenclature already exists'
+        expect(result.failure).to eq(failmsg)
+      end
+    end
+
+    context 'with new term' do
+      let(:vocab){ 'Annotation Type' }
+      let(:term){ 'Credit line' }
+      it 'returns Failure' do
+        expect(result).to be_a(Dry::Monads::Success)
+        client.delete(result.value!)
+      end
+    end
+  end
+end

--- a/spec/collectionspace/mapper/vocabulary_terms/payload_builder_spec.rb
+++ b/spec/collectionspace/mapper/vocabulary_terms/payload_builder_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CollectionSpace::Mapper::VocabularyTerms::PayloadBuilder do
+  subject(:builder){ described_class }
+
+  describe '.call' do
+    it 'returns as expected' do
+      result = builder.call(
+        domain: 'DOMAIN',
+        csid: 'CSID',
+        name: 'NAME',
+        term: 'TERM',
+        termid: 'TERMID'
+      )
+      expected = <<~XML
+           <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+           <document name="vocabularyitems">
+               <ns2:vocabularyitems_common
+                  xmlns:ns2="http://collectionspace.org/services/vocabulary"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                  <inAuthority>CSID</inAuthority>
+                  <displayName>TERM</displayName>
+                  <shortIdentifier>TERMID</shortIdentifier>
+                  <refName>
+                    urn:cspace:DOMAIN:vocabularies:name(NAME):item:name(TERMID)'TERM'
+                  </refName>
+               </ns2:vocabularyitems_common>
+           </document>
+           XML
+      expect(result).to be_a(Dry::Monads::Success)
+      expect(result.value!).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Set up a new vocabulary terms handler: 
  `vth = CollectionSpace::Mapper::VocabularyTerms::Handler.new(client: client)`

Add terms: 
  `vth.add_term(vocab: 'Annotation Type', term: 'Credit line')`
  `vth.add_term(vocab: 'persontermtype', term: 'Mage')`